### PR TITLE
Use Operation.summary attribute for titles (instead of vendor extension)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -58,8 +58,9 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/CreateChatCompletionResponse"
 
+            summary: Create chat completion
+
             x-oaiMeta:
-                name: Create chat completion
                 group: chat
                 returns: |
                     Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.
@@ -694,8 +695,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateCompletionResponse"
+            summary: Create completion
+
             x-oaiMeta:
-                name: Create completion
                 group: completions
                 returns: |
                     Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.
@@ -838,8 +840,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ImagesResponse"
+            summary: Create image
+
             x-oaiMeta:
-                name: Create image
                 group: images
                 returns: Returns a list of [image](/docs/api-reference/images/object) objects.
                 examples:
@@ -906,8 +909,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ImagesResponse"
+            summary: Create image edit
+
             x-oaiMeta:
-                name: Create image edit
                 group: images
                 returns: Returns a list of [image](/docs/api-reference/images/object) objects.
                 examples:
@@ -978,8 +982,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ImagesResponse"
+            summary: Create image variation
+
             x-oaiMeta:
-                name: Create image variation
                 group: images
                 returns: Returns a list of [image](/docs/api-reference/images/object) objects.
                 examples:
@@ -1045,8 +1050,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateEmbeddingResponse"
+            summary: Create embeddings
+
             x-oaiMeta:
-                name: Create embeddings
                 group: embeddings
                 returns: A list of [embedding](/docs/api-reference/embeddings/object) objects.
                 examples:
@@ -1132,8 +1138,9 @@ paths:
                             schema:
                                 type: string
                                 format: binary
+            summary: Create speech
+
             x-oaiMeta:
-                name: Create speech
                 group: audio
                 returns: The audio file content.
                 examples:
@@ -1200,8 +1207,9 @@ paths:
                                 oneOf:
                                     - $ref: "#/components/schemas/CreateTranscriptionResponseJson"
                                     - $ref: "#/components/schemas/CreateTranscriptionResponseVerboseJson"
+            summary: Create transcription
+
             x-oaiMeta:
-                name: Create transcription
                 group: audio
                 returns: The [transcription object](/docs/api-reference/audio/json-object) or a [verbose transcription object](/docs/api-reference/audio/verbose-json-object).
                 examples:
@@ -1386,8 +1394,9 @@ paths:
                                 oneOf:
                                     - $ref: "#/components/schemas/CreateTranslationResponseJson"
                                     - $ref: "#/components/schemas/CreateTranslationResponseVerboseJson"
+            summary: Create translation
+
             x-oaiMeta:
-                name: Create translation
                 group: audio
                 returns: The translated text.
                 examples:
@@ -1447,8 +1456,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListFilesResponse"
+            summary: List files
+
             x-oaiMeta:
-                name: List files
                 group: files
                 returns: A list of [File](/docs/api-reference/files/object) objects.
                 examples:
@@ -1524,8 +1534,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/OpenAIFile"
+            summary: Upload file
+
             x-oaiMeta:
-                name: Upload file
                 group: files
                 returns: The uploaded [File](/docs/api-reference/files/object) object.
                 examples:
@@ -1588,8 +1599,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteFileResponse"
+            summary: Delete file
+
             x-oaiMeta:
-                name: Delete file
                 group: files
                 returns: Deletion status.
                 examples:
@@ -1640,8 +1652,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/OpenAIFile"
+            summary: Retrieve file
+
             x-oaiMeta:
-                name: Retrieve file
                 group: files
                 returns: The [File](/docs/api-reference/files/object) object matching the specified ID.
                 examples:
@@ -1695,8 +1708,9 @@ paths:
                         application/json:
                             schema:
                                 type: string
+            summary: Retrieve file content
+
             x-oaiMeta:
-                name: Retrieve file content
                 group: files
                 returns: The file content.
                 examples:
@@ -1746,8 +1760,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FineTuningJob"
+            summary: Create fine-tuning job
+
             x-oaiMeta:
-                name: Create fine-tuning job
                 group: fine-tuning
                 returns: A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.
                 examples:
@@ -1971,8 +1986,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+            summary: List fine-tuning jobs
+
             x-oaiMeta:
-                name: List fine-tuning jobs
                 group: fine-tuning
                 returns: A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects.
                 examples:
@@ -2041,8 +2057,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FineTuningJob"
+            summary: Retrieve fine-tuning job
+
             x-oaiMeta:
-                name: Retrieve fine-tuning job
                 group: fine-tuning
                 returns: The [fine-tuning](/docs/api-reference/fine-tuning/object) object with the given ID.
                 examples:
@@ -2128,8 +2145,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListFineTuningJobEventsResponse"
+            summary: List fine-tuning events
+
             x-oaiMeta:
-                name: List fine-tuning events
                 group: fine-tuning
                 returns: A list of fine-tuning event objects.
                 examples:
@@ -2207,8 +2225,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FineTuningJob"
+            summary: Cancel fine-tuning
+
             x-oaiMeta:
-                name: Cancel fine-tuning
                 group: fine-tuning
                 returns: The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object.
                 examples:
@@ -2284,8 +2303,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+            summary: List fine-tuning checkpoints
+
             x-oaiMeta:
-                name: List fine-tuning checkpoints
                 group: fine-tuning
                 returns: A list of fine-tuning [checkpoint objects](/docs/api-reference/fine-tuning/checkpoint-object) for a fine-tuning job.
                 examples:
@@ -2340,8 +2360,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListModelsResponse"
+            summary: List models
+
             x-oaiMeta:
-                name: List models
                 group: models
                 returns: A list of [model](/docs/api-reference/models/object) objects.
                 examples:
@@ -2414,8 +2435,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Model"
+            summary: Retrieve model
+
             x-oaiMeta:
-                name: Retrieve model
                 group: models
                 returns: The [model](/docs/api-reference/models/object) object matching the specified ID.
                 examples:
@@ -2467,8 +2489,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteModelResponse"
+            summary: Delete a fine-tuned model
+
             x-oaiMeta:
-                name: Delete a fine-tuned model
                 group: models
                 returns: Deletion status.
                 examples:
@@ -2519,8 +2542,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateModerationResponse"
+            summary: Create moderation
+
             x-oaiMeta:
-                name: Create moderation
                 group: moderations
                 returns: A [moderation](/docs/api-reference/moderations/object) object.
                 examples:
@@ -2628,8 +2652,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListAssistantsResponse"
+            summary: List assistants
+
             x-oaiMeta:
-                name: List assistants
                 group: assistants
                 beta: true
                 returns: A list of [assistant](/docs/api-reference/assistants/object) objects.
@@ -2736,8 +2761,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/AssistantObject"
+            summary: Create assistant
+
             x-oaiMeta:
-                name: Create assistant
                 group: assistants
                 beta: true
                 returns: An [assistant](/docs/api-reference/assistants/object) object.
@@ -2897,8 +2923,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/AssistantObject"
+            summary: Retrieve assistant
+
             x-oaiMeta:
-                name: Retrieve assistant
                 group: assistants
                 beta: true
                 returns: The [assistant](/docs/api-reference/assistants/object) object matching the specified ID.
@@ -2973,8 +3000,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/AssistantObject"
+            summary: Modify assistant
+
             x-oaiMeta:
-                name: Modify assistant
                 group: assistants
                 beta: true
                 returns: The modified [assistant](/docs/api-reference/assistants/object) object.
@@ -3067,8 +3095,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteAssistantResponse"
+            summary: Delete assistant
+
             x-oaiMeta:
-                name: Delete assistant
                 group: assistants
                 beta: true
                 returns: Deletion status
@@ -3122,8 +3151,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ThreadObject"
+            summary: Create thread
+
             x-oaiMeta:
-                name: Create thread
                 group: threads
                 beta: true
                 returns: A [thread](/docs/api-reference/threads) object.
@@ -3248,8 +3278,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ThreadObject"
+            summary: Retrieve thread
+
             x-oaiMeta:
-                name: Retrieve thread
                 group: threads
                 beta: true
                 returns: The [thread](/docs/api-reference/threads/object) object matching the specified ID.
@@ -3317,8 +3348,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ThreadObject"
+            summary: Modify thread
+
             x-oaiMeta:
-                name: Modify thread
                 group: threads
                 beta: true
                 returns: The modified [thread](/docs/api-reference/threads/object) object matching the specified ID.
@@ -3394,8 +3426,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteThreadResponse"
+            summary: Delete thread
+
             x-oaiMeta:
-                name: Delete thread
                 group: threads
                 beta: true
                 returns: Deletion status
@@ -3481,8 +3514,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListMessagesResponse"
+            summary: List messages
+
             x-oaiMeta:
-                name: List messages
                 group: threads
                 beta: true
                 returns: A list of [message](/docs/api-reference/messages) objects.
@@ -3587,8 +3621,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MessageObject"
+            summary: Create message
+
             x-oaiMeta:
-                name: Create message
                 group: threads
                 beta: true
                 returns: A [message](/docs/api-reference/messages/object) object.
@@ -3676,8 +3711,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MessageObject"
+            summary: Retrieve message
+
             x-oaiMeta:
-                name: Retrieve message
                 group: threads
                 beta: true
                 returns: The [message](/docs/api-reference/threads/messages/object) object matching the specified ID.
@@ -3764,8 +3800,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MessageObject"
+            summary: Modify message
+
             x-oaiMeta:
-                name: Modify message
                 group: threads
                 beta: true
                 returns: The modified [message](/docs/api-reference/threads/messages/object) object.
@@ -3860,8 +3897,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteMessageResponse"
+            summary: Delete message
+
             x-oaiMeta:
-                name: Delete message
                 group: threads
                 beta: true
                 returns: Deletion status
@@ -3920,8 +3958,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Create thread and run
+
             x-oaiMeta:
-                name: Create thread and run
                 group: threads
                 beta: true
                 returns: A [run](/docs/api-reference/runs/object) object.
@@ -4317,8 +4356,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListRunsResponse"
+            summary: List runs
+
             x-oaiMeta:
-                name: List runs
                 group: threads
                 beta: true
                 returns: A list of [run](/docs/api-reference/runs/object) objects.
@@ -4478,8 +4518,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Create run
+
             x-oaiMeta:
-                name: Create run
                 group: threads
                 beta: true
                 returns: A [run](/docs/api-reference/runs/object) object.
@@ -4820,8 +4861,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Retrieve run
+
             x-oaiMeta:
-                name: Retrieve run
                 group: threads
                 beta: true
                 returns: The [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -4926,8 +4968,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Modify run
+
             x-oaiMeta:
-                name: Modify run
                 group: threads
                 beta: true
                 returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -5057,8 +5100,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Submit tool outputs to run
+
             x-oaiMeta:
-                name: Submit tool outputs to run
                 group: threads
                 beta: true
                 returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -5306,8 +5350,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Cancel a run
+
             x-oaiMeta:
-                name: Cancel a run
                 group: threads
                 beta: true
                 returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -5426,8 +5471,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListRunStepsResponse"
+            summary: List run steps
+
             x-oaiMeta:
-                name: List run steps
                 group: threads
                 beta: true
                 returns: A list of [run step](/docs/api-reference/runs/step-object) objects.
@@ -5529,8 +5575,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunStepObject"
+            summary: Retrieve run step
+
             x-oaiMeta:
-                name: Retrieve run step
                 group: threads
                 beta: true
                 returns: The [run step](/docs/api-reference/runs/step-object) object matching the specified ID.
@@ -5632,8 +5679,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListVectorStoresResponse"
+            summary: List vector stores
+
             x-oaiMeta:
-                name: List vector stores
                 group: vector_stores
                 beta: true
                 returns: A list of [vector store](/docs/api-reference/vector-stores/object) objects.
@@ -5715,8 +5763,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreObject"
+            summary: Create vector store
+
             x-oaiMeta:
-                name: Create vector store
                 group: vector_stores
                 beta: true
                 returns: A [vector store](/docs/api-reference/vector-stores/object) object.
@@ -5786,8 +5835,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreObject"
+            summary: Retrieve vector store
+
             x-oaiMeta:
-                name: Retrieve vector store
                 group: vector_stores
                 beta: true
                 returns: The [vector store](/docs/api-reference/vector-stores/object) object matching the specified ID.
@@ -5849,8 +5899,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreObject"
+            summary: Modify vector store
+
             x-oaiMeta:
-                name: Modify vector store
                 group: vector_stores
                 beta: true
                 returns: The modified [vector store](/docs/api-reference/vector-stores/object) object.
@@ -5923,8 +5974,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteVectorStoreResponse"
+            summary: Delete vector store
+
             x-oaiMeta:
-                name: Delete vector store
                 group: vector_stores
                 beta: true
                 returns: Deletion status
@@ -6013,8 +6065,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            summary: List vector store files
+
             x-oaiMeta:
-                name: List vector store files
                 group: vector_stores
                 beta: true
                 returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
@@ -6093,8 +6146,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileObject"
+            summary: Create vector store file
+
             x-oaiMeta:
-                name: Create vector store file
                 group: vector_stores
                 beta: true
                 returns: A [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
@@ -6171,8 +6225,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileObject"
+            summary: Retrieve vector store file
+
             x-oaiMeta:
-                name: Retrieve vector store file
                 group: vector_stores
                 beta: true
                 returns: The [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
@@ -6239,8 +6294,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteVectorStoreFileResponse"
+            summary: Delete vector store file
+
             x-oaiMeta:
-                name: Delete vector store file
                 group: vector_stores
                 beta: true
                 returns: Deletion status
@@ -6309,8 +6365,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            summary: Create vector store file batch
+
             x-oaiMeta:
-                name: Create vector store file batch
                 group: vector_stores
                 beta: true
                 returns: A [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
@@ -6392,8 +6449,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            summary: Retrieve vector store file batch
+
             x-oaiMeta:
-                name: Retrieve vector store file batch
                 group: vector_stores
                 beta: true
                 returns: The [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
@@ -6468,8 +6526,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            summary: Cancel vector store file batch
+
             x-oaiMeta:
-                name: Cancel vector store file batch
                 group: vector_stores
                 beta: true
                 returns: The modified vector store file batch object.
@@ -6575,8 +6634,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            summary: List vector store files in a batch
+
             x-oaiMeta:
-                name: List vector store files in a batch
                 group: vector_stores
                 beta: true
                 returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
@@ -6682,8 +6742,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Batch"
+            summary: Create batch
+
             x-oaiMeta:
-                name: Create batch
                 group: batch
                 returns: The created [Batch](/docs/api-reference/batch/object) object.
                 examples:
@@ -6778,8 +6839,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListBatchesResponse"
+            summary: List batch
+
             x-oaiMeta:
-                name: List batch
                 group: batch
                 returns: A list of paginated [Batch](/docs/api-reference/batch/object) objects.
                 examples:
@@ -6867,8 +6929,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Batch"
+            summary: Retrieve batch
+
             x-oaiMeta:
-                name: Retrieve batch
                 group: batch
                 returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
                 examples:
@@ -6945,8 +7008,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Batch"
+            summary: Cancel batch
+
             x-oaiMeta:
-                name: Cancel batch
                 group: batch
                 returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
                 examples:


### PR DESCRIPTION
This commit moves the `x-oaiMeta.name` properties of each [Operation Object](https://spec.openapis.org/oas/v3.1.0#operation-object) of the OpenAPI spec in their respective `summary` property (which is the main intent of the spec to store a “short summary”, i.e. a title).