### PR TITLE
Add `x-oaiMeta` data back

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,6 +61,7 @@ paths:
             summary: Create chat completion
 
             x-oaiMeta:
+                name: Create chat completion
                 group: chat
                 returns: |
                     Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.
@@ -698,6 +699,7 @@ paths:
             summary: Create completion
 
             x-oaiMeta:
+                name: Create completion
                 group: completions
                 returns: |
                     Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.
@@ -843,6 +845,7 @@ paths:
             summary: Create image
 
             x-oaiMeta:
+                name: Create image
                 group: images
                 returns: Returns a list of [image](/docs/api-reference/images/object) objects.
                 examples:
@@ -912,6 +915,7 @@ paths:
             summary: Create image edit
 
             x-oaiMeta:
+                name: Create image edit
                 group: images
                 returns: Returns a list of [image](/docs/api-reference/images/object) objects.
                 examples:
@@ -985,6 +989,7 @@ paths:
             summary: Create image variation
 
             x-oaiMeta:
+                name: Create image variation
                 group: images
                 returns: Returns a list of [image](/docs/api-reference/images/object) objects.
                 examples:
@@ -1053,6 +1058,7 @@ paths:
             summary: Create embeddings
 
             x-oaiMeta:
+                name: Create embeddings
                 group: embeddings
                 returns: A list of [embedding](/docs/api-reference/embeddings/object) objects.
                 examples:
@@ -1141,6 +1147,7 @@ paths:
             summary: Create speech
 
             x-oaiMeta:
+                name: Create speech
                 group: audio
                 returns: The audio file content.
                 examples:
@@ -1210,6 +1217,7 @@ paths:
             summary: Create transcription
 
             x-oaiMeta:
+                name: Create transcription
                 group: audio
                 returns: The [transcription object](/docs/api-reference/audio/json-object) or a [verbose transcription object](/docs/api-reference/audio/verbose-json-object).
                 examples:
@@ -1397,6 +1405,7 @@ paths:
             summary: Create translation
 
             x-oaiMeta:
+                name: Create translation
                 group: audio
                 returns: The translated text.
                 examples:
@@ -1459,6 +1468,7 @@ paths:
             summary: List files
 
             x-oaiMeta:
+                name: List files
                 group: files
                 returns: A list of [File](/docs/api-reference/files/object) objects.
                 examples:
@@ -1537,6 +1547,7 @@ paths:
             summary: Upload file
 
             x-oaiMeta:
+                name: Upload file
                 group: files
                 returns: The uploaded [File](/docs/api-reference/files/object) object.
                 examples:
@@ -1602,6 +1613,7 @@ paths:
             summary: Delete file
 
             x-oaiMeta:
+                name: Delete file
                 group: files
                 returns: Deletion status.
                 examples:
@@ -1655,6 +1667,7 @@ paths:
             summary: Retrieve file
 
             x-oaiMeta:
+                name: Retrieve file
                 group: files
                 returns: The [File](/docs/api-reference/files/object) object matching the specified ID.
                 examples:
@@ -1711,6 +1724,7 @@ paths:
             summary: Retrieve file content
 
             x-oaiMeta:
+                name: Retrieve file content
                 group: files
                 returns: The file content.
                 examples:
@@ -1763,6 +1777,7 @@ paths:
             summary: Create fine-tuning job
 
             x-oaiMeta:
+                name: Create fine-tuning job
                 group: fine-tuning
                 returns: A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object.
                 examples:
@@ -1989,6 +2004,7 @@ paths:
             summary: List fine-tuning jobs
 
             x-oaiMeta:
+                name: List fine-tuning jobs
                 group: fine-tuning
                 returns: A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects.
                 examples:
@@ -2060,6 +2076,7 @@ paths:
             summary: Retrieve fine-tuning job
 
             x-oaiMeta:
+                name: Retrieve fine-tuning job
                 group: fine-tuning
                 returns: The [fine-tuning](/docs/api-reference/fine-tuning/object) object with the given ID.
                 examples:
@@ -2148,6 +2165,7 @@ paths:
             summary: List fine-tuning events
 
             x-oaiMeta:
+                name: List fine-tuning events
                 group: fine-tuning
                 returns: A list of fine-tuning event objects.
                 examples:
@@ -2228,6 +2246,7 @@ paths:
             summary: Cancel fine-tuning
 
             x-oaiMeta:
+                name: Cancel fine-tuning
                 group: fine-tuning
                 returns: The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object.
                 examples:
@@ -2306,6 +2325,7 @@ paths:
             summary: List fine-tuning checkpoints
 
             x-oaiMeta:
+                name: List fine-tuning checkpoints
                 group: fine-tuning
                 returns: A list of fine-tuning [checkpoint objects](/docs/api-reference/fine-tuning/checkpoint-object) for a fine-tuning job.
                 examples:
@@ -2363,6 +2383,7 @@ paths:
             summary: List models
 
             x-oaiMeta:
+                name: List models
                 group: models
                 returns: A list of [model](/docs/api-reference/models/object) objects.
                 examples:
@@ -2438,6 +2459,7 @@ paths:
             summary: Retrieve model
 
             x-oaiMeta:
+                name: Retrieve model
                 group: models
                 returns: The [model](/docs/api-reference/models/object) object matching the specified ID.
                 examples:
@@ -2492,6 +2514,7 @@ paths:
             summary: Delete a fine-tuned model
 
             x-oaiMeta:
+                name: Delete a fine-tuned model
                 group: models
                 returns: Deletion status.
                 examples:
@@ -2545,6 +2568,7 @@ paths:
             summary: Create moderation
 
             x-oaiMeta:
+                name: Create moderation
                 group: moderations
                 returns: A [moderation](/docs/api-reference/moderations/object) object.
                 examples:
@@ -2655,6 +2679,7 @@ paths:
             summary: List assistants
 
             x-oaiMeta:
+                name: List assistants
                 group: assistants
                 beta: true
                 returns: A list of [assistant](/docs/api-reference/assistants/object) objects.
@@ -2764,6 +2789,7 @@ paths:
             summary: Create assistant
 
             x-oaiMeta:
+                name: Create assistant
                 group: assistants
                 beta: true
                 returns: An [assistant](/docs/api-reference/assistants/object) object.
@@ -2926,6 +2952,7 @@ paths:
             summary: Retrieve assistant
 
             x-oaiMeta:
+                name: Retrieve assistant
                 group: assistants
                 beta: true
                 returns: The [assistant](/docs/api-reference/assistants/object) object matching the specified ID.
@@ -3003,6 +3030,7 @@ paths:
             summary: Modify assistant
 
             x-oaiMeta:
+                name: Modify assistant
                 group: assistants
                 beta: true
                 returns: The modified [assistant](/docs/api-reference/assistants/object) object.
@@ -3098,6 +3126,7 @@ paths:
             summary: Delete assistant
 
             x-oaiMeta:
+                name: Delete assistant
                 group: assistants
                 beta: true
                 returns: Deletion status
@@ -3154,6 +3183,7 @@ paths:
             summary: Create thread
 
             x-oaiMeta:
+                name: Create thread
                 group: threads
                 beta: true
                 returns: A [thread](/docs/api-reference/threads) object.
@@ -3281,6 +3311,7 @@ paths:
             summary: Retrieve thread
 
             x-oaiMeta:
+                name: Retrieve thread
                 group: threads
                 beta: true
                 returns: The [thread](/docs/api-reference/threads/object) object matching the specified ID.
@@ -3351,6 +3382,7 @@ paths:
             summary: Modify thread
 
             x-oaiMeta:
+                name: Modify thread
                 group: threads
                 beta: true
                 returns: The modified [thread](/docs/api-reference/threads/object) object matching the specified ID.
@@ -3429,6 +3461,7 @@ paths:
             summary: Delete thread
 
             x-oaiMeta:
+                name: Delete thread
                 group: threads
                 beta: true
                 returns: Deletion status
@@ -3517,6 +3550,7 @@ paths:
             summary: List messages
 
             x-oaiMeta:
+                name: List messages
                 group: threads
                 beta: true
                 returns: A list of [message](/docs/api-reference/messages) objects.
@@ -3624,6 +3658,7 @@ paths:
             summary: Create message
 
             x-oaiMeta:
+                name: Create message
                 group: threads
                 beta: true
                 returns: A [message](/docs/api-reference/messages/object) object.
@@ -3714,6 +3749,7 @@ paths:
             summary: Retrieve message
 
             x-oaiMeta:
+                name: Retrieve message
                 group: threads
                 beta: true
                 returns: The [message](/docs/api-reference/threads/messages/object) object matching the specified ID.
@@ -3803,6 +3839,7 @@ paths:
             summary: Modify message
 
             x-oaiMeta:
+                name: Modify message
                 group: threads
                 beta: true
                 returns: The modified [message](/docs/api-reference/threads/messages/object) object.
@@ -3900,6 +3937,7 @@ paths:
             summary: Delete message
 
             x-oaiMeta:
+                name: Delete message
                 group: threads
                 beta: true
                 returns: Deletion status
@@ -3961,6 +3999,7 @@ paths:
             summary: Create thread and run
 
             x-oaiMeta:
+                name: Create thread and run
                 group: threads
                 beta: true
                 returns: A [run](/docs/api-reference/runs/object) object.
@@ -4360,6 +4399,7 @@ paths:
             summary: List runs
 
             x-oaiMeta:
+                name: List runs
                 group: threads
                 beta: true
                 returns: A list of [run](/docs/api-reference/runs/object) objects.
@@ -4524,6 +4564,7 @@ paths:
             summary: Create run
 
             x-oaiMeta:
+                name: Create run
                 group: threads
                 beta: true
                 returns: A [run](/docs/api-reference/runs/object) object.
@@ -4868,6 +4909,7 @@ paths:
             summary: Retrieve run
 
             x-oaiMeta:
+                name: Retrieve run
                 group: threads
                 beta: true
                 returns: The [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -4976,6 +5018,7 @@ paths:
             summary: Modify run
 
             x-oaiMeta:
+                name: Modify run
                 group: threads
                 beta: true
                 returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -5109,6 +5152,7 @@ paths:
             summary: Submit tool outputs to run
 
             x-oaiMeta:
+                name: Submit tool outputs to run
                 group: threads
                 beta: true
                 returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -5360,6 +5404,7 @@ paths:
             summary: Cancel a run
 
             x-oaiMeta:
+                name: Cancel a run
                 group: threads
                 beta: true
                 returns: The modified [run](/docs/api-reference/runs/object) object matching the specified ID.
@@ -5483,6 +5528,7 @@ paths:
             summary: List run steps
 
             x-oaiMeta:
+                name: List run steps
                 group: threads
                 beta: true
                 returns: A list of [run step](/docs/api-reference/runs/step-object) objects.
@@ -5587,6 +5633,7 @@ paths:
             summary: Retrieve run step
 
             x-oaiMeta:
+                name: Retrieve run step
                 group: threads
                 beta: true
                 returns: The [run step](/docs/api-reference/runs/step-object) object matching the specified ID.
@@ -5691,6 +5738,7 @@ paths:
             summary: List vector stores
 
             x-oaiMeta:
+                name: List vector stores
                 group: vector_stores
                 beta: true
                 returns: A list of [vector store](/docs/api-reference/vector-stores/object) objects.
@@ -5775,6 +5823,7 @@ paths:
             summary: Create vector store
 
             x-oaiMeta:
+                name: Create vector store
                 group: vector_stores
                 beta: true
                 returns: A [vector store](/docs/api-reference/vector-stores/object) object.
@@ -5847,6 +5896,7 @@ paths:
             summary: Retrieve vector store
 
             x-oaiMeta:
+                name: Retrieve vector store
                 group: vector_stores
                 beta: true
                 returns: The [vector store](/docs/api-reference/vector-stores/object) object matching the specified ID.
@@ -5911,6 +5961,7 @@ paths:
             summary: Modify vector store
 
             x-oaiMeta:
+                name: Modify vector store
                 group: vector_stores
                 beta: true
                 returns: The modified [vector store](/docs/api-reference/vector-stores/object) object.
@@ -5986,6 +6037,7 @@ paths:
             summary: Delete vector store
 
             x-oaiMeta:
+                name: Delete vector store
                 group: vector_stores
                 beta: true
                 returns: Deletion status
@@ -6077,6 +6129,7 @@ paths:
             summary: List vector store files
 
             x-oaiMeta:
+                name: List vector store files
                 group: vector_stores
                 beta: true
                 returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
@@ -6158,6 +6211,7 @@ paths:
             summary: Create vector store file
 
             x-oaiMeta:
+                name: Create vector store file
                 group: vector_stores
                 beta: true
                 returns: A [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
@@ -6237,6 +6291,7 @@ paths:
             summary: Retrieve vector store file
 
             x-oaiMeta:
+                name: Retrieve vector store file
                 group: vector_stores
                 beta: true
                 returns: The [vector store file](/docs/api-reference/vector-stores-files/file-object) object.
@@ -6306,6 +6361,7 @@ paths:
             summary: Delete vector store file
 
             x-oaiMeta:
+                name: Delete vector store file
                 group: vector_stores
                 beta: true
                 returns: Deletion status
@@ -6377,6 +6433,7 @@ paths:
             summary: Create vector store file batch
 
             x-oaiMeta:
+                name: Create vector store file batch
                 group: vector_stores
                 beta: true
                 returns: A [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
@@ -6461,6 +6518,7 @@ paths:
             summary: Retrieve vector store file batch
 
             x-oaiMeta:
+                name: Retrieve vector store file batch
                 group: vector_stores
                 beta: true
                 returns: The [vector store file batch](/docs/api-reference/vector-stores-file-batches/batch-object) object.
@@ -6538,6 +6596,7 @@ paths:
             summary: Cancel vector store file batch
 
             x-oaiMeta:
+                name: Cancel vector store file batch
                 group: vector_stores
                 beta: true
                 returns: The modified vector store file batch object.
@@ -6646,6 +6705,7 @@ paths:
             summary: List vector store files in a batch
 
             x-oaiMeta:
+                name: List vector store files in a batch
                 group: vector_stores
                 beta: true
                 returns: A list of [vector store file](/docs/api-reference/vector-stores-files/file-object) objects.
@@ -6754,6 +6814,7 @@ paths:
             summary: Create batch
 
             x-oaiMeta:
+                name: Create batch
                 group: batch
                 returns: The created [Batch](/docs/api-reference/batch/object) object.
                 examples:
@@ -6851,6 +6912,7 @@ paths:
             summary: List batch
 
             x-oaiMeta:
+                name: List batch
                 group: batch
                 returns: A list of paginated [Batch](/docs/api-reference/batch/object) objects.
                 examples:
@@ -6941,6 +7003,7 @@ paths:
             summary: Retrieve batch
 
             x-oaiMeta:
+                name: Retrieve batch
                 group: batch
                 returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
                 examples:
@@ -7020,6 +7083,7 @@ paths:
             summary: Cancel batch
 
             x-oaiMeta:
+                name: Cancel batch
                 group: batch
                 returns: The [Batch](/docs/api-reference/batch/object) object matching the specified ID.
                 examples:


### PR DESCRIPTION
Followup up to #1 to keep the `x-oaiMeta` data which is used by the OpenAI documentation UI